### PR TITLE
Display Simon Says game sequence

### DIFF
--- a/SimonSays.st
+++ b/SimonSays.st
@@ -1,0 +1,130 @@
+// MAIN is N.C. → LED on when pressed 
+OLED_MAIN := NOT IBTN_MAIN;  
+
+// Color buttons → LED (when not in sequence display mode)
+IF NOT SeqDisplay_Active THEN
+    OLED_B := IBTN_B;     
+    OLED_R := IBTN_R;        
+    OLED_Y := IBTN_Y;      
+END_IF;
+
+//  main game logic
+Trig_Start(Clk := IBTN_B, Q => B);
+
+IF B THEN
+    Rand_Gen(Execute := TRUE, Seed := 0, Rnd => RandN);
+
+    IF RandN < 0.333 THEN
+        L_N := 1;  // Yellow
+    ELSIF RandN < 0.666 THEN
+        L_N := 2;  // Blue
+    ELSE
+        L_N := 3;  // Red
+    END_IF;
+
+    IF WriteIndex >= 50 THEN
+        WriteIndex := 0;
+        ArrayFull := TRUE;
+    ELSIF WriteIndex < 0 THEN
+        WriteIndex := 0;
+    END_IF;
+
+    Idx := TO_INT(WriteIndex);
+    GameFlow_SN[Idx] := L_N;
+    WriteIndex := WriteIndex + 1;
+    
+    // Trigger sequence display after adding new number
+    SeqDisplay_Active := TRUE;
+    SeqDisplay_Index := 0;
+    SeqDisplay_Step := 0;  // 0 = LED ON, 1 = LED OFF
+    T_SeqDisplay(IN := FALSE, PT := T#300ms);
+END_IF;
+
+
+// --- Sequence Display Logic ---
+IF SeqDisplay_Active THEN
+    IF NOT T_SeqDisplay.Q THEN
+        T_SeqDisplay(IN := TRUE, PT := T#300ms);
+    ELSE
+        T_SeqDisplay(IN := FALSE, PT := T#300ms);
+    END_IF;
+
+    Trig_SeqTick(CLK := T_SeqDisplay.Q);
+    SeqDisplay_Tick := Trig_SeqTick.Q;
+
+    IF SeqDisplay_Tick THEN
+        IF SeqDisplay_Step = 0 THEN
+            // LED ON - display current sequence element
+            CASE GameFlow_SN[SeqDisplay_Index] OF
+                1:  OLED_Y := TRUE;  OLED_B := FALSE; OLED_R := FALSE;  // Yellow
+                2:  OLED_Y := FALSE; OLED_B := TRUE;  OLED_R := FALSE;  // Blue
+                3:  OLED_Y := FALSE; OLED_B := FALSE; OLED_R := TRUE;   // Red
+                ELSE
+                    OLED_Y := FALSE; OLED_B := FALSE; OLED_R := FALSE;
+            END_CASE;
+            SeqDisplay_Step := 1;
+        ELSE
+            // LED OFF - pause between elements
+            OLED_Y := FALSE; OLED_B := FALSE; OLED_R := FALSE;
+            SeqDisplay_Step := 0;
+            SeqDisplay_Index := SeqDisplay_Index + 1;
+            
+            // Check if we've displayed the entire sequence
+            IF SeqDisplay_Index >= WriteIndex THEN
+                SeqDisplay_Active := FALSE;
+                OLED_Y := FALSE; OLED_B := FALSE; OLED_R := FALSE;
+            END_IF;
+        END_IF;
+    END_IF;
+END_IF;
+
+
+// -auto-reset edge when WriteIndex hits 50 
+Trig_Wrap(CLK := (WriteIndex = 50));
+ResetReq := RI OR Trig_Wrap.Q;      // manual RI or auto edge at 50
+Trig_Reset(CLK := ResetReq);
+
+IF Trig_Reset.Q THEN
+    AryAddV(In1 := GameFlow_S[0], In2 := L_N, Size := 50, AryOut := GameFlow_SN[0]);
+
+    GameOver_Active := TRUE;
+    GameOver_Step := -1;
+    T_Seq(IN := FALSE, PT := T#300ms);
+
+    WriteIndex := 0;
+    ArrayFull := TRUE;
+END_IF;
+
+
+// --- game over LED sequence (R -> B -> Y, once) ---
+IF GameOver_Active THEN
+    IF NOT T_Seq.Q THEN
+        T_Seq(IN := TRUE, PT := T#300ms);
+    ELSE
+        T_Seq(IN := FALSE, PT := T#300ms);
+    END_IF;
+
+    Trig_Tick(CLK := T_Seq.Q);
+    GameOver_Tick := Trig_Tick.Q;
+
+    IF GameOver_Tick THEN
+        GameOver_Step := GameOver_Step + 1;
+    END_IF;
+
+    CASE GameOver_Step OF
+        0:  OLED_R := TRUE;  OLED_B := FALSE; OLED_Y := FALSE;
+        1:  OLED_R := FALSE; OLED_B := TRUE;  OLED_Y := FALSE;
+        2:  OLED_R := FALSE; OLED_B := FALSE; OLED_Y := TRUE;
+        4:  OLED_R := FALSE; OLED_B := FALSE; OLED_Y := FALSE;
+        5:  OLED_R := TRUE;  OLED_B := TRUE;  OLED_Y := TRUE;
+        6:  OLED_R := FALSE; OLED_B := FALSE; OLED_Y := FALSE;
+        7:  OLED_R := TRUE;  OLED_B := TRUE;  OLED_Y := TRUE;
+        ELSE
+            OLED_R := FALSE; OLED_B := FALSE; OLED_Y := FALSE;
+    END_CASE;
+
+    IF GameOver_Step > 7 THEN
+        GameOver_Active := FALSE;
+        OLED_R := FALSE; OLED_B := FALSE; OLED_Y := FALSE;
+    END_IF;
+END_IF;

--- a/VARIABLES_NEEDED.md
+++ b/VARIABLES_NEEDED.md
@@ -1,0 +1,30 @@
+# New Variables Required for Sequence Display
+
+Add these variables to your variable declaration section:
+
+```
+// Sequence Display Variables
+SeqDisplay_Active   : BOOL := FALSE;   // TRUE when displaying sequence
+SeqDisplay_Index    : INT := 0;        // Current position in sequence being displayed
+SeqDisplay_Step     : INT := 0;        // 0 = LED ON, 1 = LED OFF (pause)
+SeqDisplay_Tick     : BOOL;            // Edge trigger for sequence timing
+T_SeqDisplay        : TON;             // Timer for sequence display (300ms intervals)
+Trig_SeqTick        : R_TRIG;          // Rising edge trigger for sequence steps
+```
+
+## How It Works
+
+1. **After each round**: When a new random number is added to `GameFlow_SN`, the sequence display is triggered
+2. **Display sequence**: The game iterates through the array from index 0 to `WriteIndex-1`
+3. **LED mapping**: 
+   - 1 = Yellow LED (OLED_Y)
+   - 2 = Blue LED (OLED_B)
+   - 3 = Red LED (OLED_R)
+4. **Timing**: Each LED lights up for 300ms, then turns off for 300ms before showing the next one
+5. **Growth**: Round 1 shows 1 light, Round 2 shows 2 lights in sequence, Round 20 shows all 20 lights in order
+
+## Key Changes
+
+- Button LED control is now conditional: `IF NOT SeqDisplay_Active THEN` to prevent manual button presses from interfering during sequence display
+- Sequence automatically plays after each round
+- Uses the same 300ms timing as your game over sequence for consistency


### PR DESCRIPTION
Add sequence display functionality to the Simon Says game to show the current pattern after each round.

---
<a href="https://cursor.com/background-agent?bcId=bc-4dbb2616-c25f-40da-a875-3655fd3fd325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4dbb2616-c25f-40da-a875-3655fd3fd325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

